### PR TITLE
IoCifies the Oscillator's polysynth instance.

### DIFF
--- a/js/oscillator.js
+++ b/js/oscillator.js
@@ -24,6 +24,27 @@ var automm = automm || {};
         preInitFunction: "automm.oscillator.preInitFunction",
         postInitFunction: "automm.oscillator.postInitFunction",
 
+        components: {
+            polysynth: {
+                type: "flock.synth.polyphonic",
+                options: {
+                    // TODO: Generate this synthDef using model transformation.
+                    synthDef: {
+                        id: "carrier",
+                        ugen: "{oscillator}.model.osc",
+                        freq: "{oscillator}.model.freq",
+                        mul: {
+                            id: "env",
+                            ugen: "flock.ugen.env.simpleASR",
+                            attack: "{oscillator}.model.attack",
+                            sustain: "{oscillator}.model.sustain",
+                            release: "{oscillator}.model.release"
+                        }
+                    }
+                }
+            }
+        },
+        
         model: {
             arpActive: false,
             freq: 440,
@@ -45,6 +66,7 @@ var automm = automm || {};
             afterClick: null,
             afterInstrumentUpdate: null
         },
+        
         // Maps parameter between this model and the model of flocking
         paramMap: {
             "freq": "carrier.freq",
@@ -60,19 +82,6 @@ var automm = automm || {};
             flock.init();
         }
         
-        that.polysynth = flock.synth.polyphonic({
-            id: "carrier",
-            ugen: that.model.osc,
-            freq: that.model.freq,
-            mul: {
-                id: "env",
-                ugen: "flock.ugen.env.simpleASR",
-                attack: that.model.attack,
-                sustain: that.model.sustain,
-                release: that.model.release
-            }
-        });
-
         that.update = function (param, value) {
             if (that.model.hasOwnProperty(param)) {
                 that.applier.requestChange(param, value);


### PR DESCRIPTION
This should make it easier for users of the AMM to provide their own custom synthesizers. 

Also updates to the latest version of Flocking master. This should be the last API-breaking change before the Flocking 0.1 release. 

I'm planning to demonstrate how to use the AMMM to create a Flocking-based synthesizer at the SuperCollider 2013 Symposium this week, which should be cool.
